### PR TITLE
aws: make MaxRetries for API calls configurable

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -18,10 +18,11 @@ import (
 )
 
 type Config struct {
-	AccessKey string
-	SecretKey string
-	Token     string
-	Region    string
+	AccessKey  string
+	SecretKey  string
+	Token      string
+	Region     string
+	MaxRetries int
 
 	AllowedAccountIds   []interface{}
 	ForbiddenAccountIds []interface{}
@@ -62,6 +63,7 @@ func (c *Config) Client() (interface{}, error) {
 		awsConfig := &aws.Config{
 			Credentials: creds,
 			Region:      c.Region,
+			MaxRetries:  c.MaxRetries,
 		}
 
 		log.Println("[INFO] Initializing ELB connection")
@@ -94,6 +96,7 @@ func (c *Config) Client() (interface{}, error) {
 		client.r53conn = route53.New(&aws.Config{
 			Credentials: creds,
 			Region:      "us-east-1",
+			MaxRetries:  c.MaxRetries,
 		})
 
 	}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -53,6 +53,13 @@ func Provider() terraform.ResourceProvider {
 				InputDefault: "us-east-1",
 			},
 
+			"max_retries": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     11,
+				Description: descriptions["max_retries"],
+			},
+
 			"allowed_account_ids": &schema.Schema{
 				Type:          schema.TypeSet,
 				Elem:          &schema.Schema{Type: schema.TypeString},
@@ -120,15 +127,20 @@ func init() {
 
 		"token": "session token. A session token is only required if you are\n" +
 			"using temporary security credentials.",
+
+		"max_retries": "The maximum number of times an AWS API request is\n" +
+			"being executed. If the API request still fails, an error is\n" +
+			"thrown.",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		AccessKey: d.Get("access_key").(string),
-		SecretKey: d.Get("secret_key").(string),
-		Token:     d.Get("token").(string),
-		Region:    d.Get("region").(string),
+		AccessKey:  d.Get("access_key").(string),
+		SecretKey:  d.Get("secret_key").(string),
+		Token:      d.Get("token").(string),
+		Region:     d.Get("region").(string),
+		MaxRetries: d.Get("max_retries").(int),
 	}
 
 	if v, ok := d.GetOk("allowed_account_ids"); ok {

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -43,6 +43,10 @@ The following arguments are supported in the `provider` block:
 * `region` - (Required) This is the AWS region. It must be provided, but
   it can also be sourced from the `AWS_DEFAULT_REGION` environment variables.
 
+* `max_retries` - (Optional) This is the maximum number of times an API call is
+  being retried in case requests are being throttled or experience transient failures.
+  The delay between the subsequent API calls increases exponentially.
+
 * `allowed_account_ids` - (Optional) List of allowed AWS account IDs (whitelist)
   to prevent you mistakenly using a wrong one (and end up destroying live environment).
   Conflicts with `forbidden_account_ids`.


### PR DESCRIPTION
- Make it configurable in the AWS provider by add an option
  'max_retries'.
- Set the default from 3 to 11 retries.